### PR TITLE
Reset timeout on every loop through wait_for()

### DIFF
--- a/source/ipc_impl.hpp
+++ b/source/ipc_impl.hpp
@@ -30,7 +30,6 @@ namespace ipc
     template<bool Reading, typename Predicate>
     static bool wait_for(socket_t s, const Predicate& predicate)
     {
-        timeval timeout = { 1, 0 };
         int count = 0;
         while (count == 0)
         {
@@ -40,6 +39,7 @@ namespace ipc
             fd_set fds;
             FD_ZERO(&fds);
             FD_SET(s, &fds);
+            timeval timeout = { 1, 0 };
             if constexpr (Reading)
                 count = select(FD_SETSIZE, &fds, nullptr, nullptr, &timeout);
             else


### PR DESCRIPTION
Under Linux, select() returns the time remaining until timeout in the timeout parameter.   As such, according to the manpage, it should be "assumed to be undefined" after a call to select().   The existing code creates timeout _outside_ of the while loop, so after the first timeout, the code runs as essentially max rate and server process drives one CPU core to 100%

The attached patch moves the definition of timeout just before the select(), so it is reset before every call.